### PR TITLE
Include Patch for GMP on GCC 15

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -345,6 +345,7 @@ install_cross_compiler() {
     if [[ ($compiler_flavors == "win32" || $compiler_flavors == "multi") && ! -f ../$win32_gcc ]]; then
       echo "Building win32 cross compiler..."
       download_gcc_build_script $zeranoe_script_name
+      download_gcc_build_script "gmp-gcc-15.patch"
       if [[ `uname` =~ "5.1" ]]; then # Avoid using secure API functions for compatibility with msvcrt.dll on Windows XP.
         sed -i "s/ --enable-secure-api//" $zeranoe_script_name
       fi
@@ -361,6 +362,7 @@ install_cross_compiler() {
     if [[ ($compiler_flavors == "win64" || $compiler_flavors == "multi") && ! -f ../$win64_gcc ]]; then
       echo "Building win64 x86_64 cross compiler..."
       download_gcc_build_script $zeranoe_script_name
+      download_gcc_build_script "gmp-gcc-15.patch"
       CFLAGS=-O2 CXXFLAGS=-O2 nice ./$zeranoe_script_name $zeranoe_script_options --build-type=win64 || exit 1
       if [[ ! -f ../$win64_gcc ]]; then
         echo "Failure building 64 bit gcc? Recommend nuke sandbox (rm -rf sandbox) and start over..."

--- a/patches/gmp-gcc-15.patch
+++ b/patches/gmp-gcc-15.patch
@@ -1,0 +1,21 @@
+
+# HG changeset patch
+# User Marc Glisse <marc.glisse@inria.fr>
+# Date 1738186682 -3600
+# Node ID 8e7bb4ae7a18b1405ea7f9cbcda450b7d920a901
+# Parent  e84c5c785bbe8ed8c3620194e50b65adfc2f5d83
+Complete function prototype in acinclude.m4 for C23 compatibility
+
+diff -r e84c5c785bbe -r 8e7bb4ae7a18 acinclude.m4
+--- a/acinclude.m4	Wed Dec 04 18:26:27 2024 +0100
++++ b/acinclude.m4	Wed Jan 29 22:38:02 2025 +0100
+@@ -609,7 +609,7 @@
+ 
+ #if defined (__GNUC__) && ! defined (__cplusplus)
+ typedef unsigned long long t1;typedef t1*t2;
+-void g(){}
++void g(int,t1 const*,t1,t2,t1 const*,int){}
+ void h(){}
+ static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
+ {t1 c,x,r;int i;if(v0){c=1;for(i=1;i<n;i++){x=up[i];r=x+1;rp[i]=r;}}return c;}
+

--- a/patches/mingw-w64-build-r22.local
+++ b/patches/mingw-w64-build-r22.local
@@ -609,6 +609,17 @@ std_compile ()
 
   download_extract "$url"
 
+  # Patch for GMP on GCC 15
+  if [ "$pkg" = "gmp" ]; then
+    local gccver=$(gcc -dumpversion)
+    if [ "$gccver" -gt 14 ]; then
+      cd "$pkg-$ver"
+      patch -p1 < "../../../../gmp-gcc-15.patch"
+      autoreconf -vif
+      cd ".."
+    fi
+  fi
+
   if ! check_pkg_touch_success "$pkg" "$ver" 'configure' "$uname_m"; then
     clean_build
     build_progress "$pkg" 'Configuring'


### PR DESCRIPTION
Closes https://github.com/EnsignPayton/ffmpeg-windows-build-helpers/issues/3

To build FFmpeg for Windows, we need a cross-compiler. In this case, we're using GCC. Building a cross-compiling GCC requires GMP. GMP was failing in `configure` due to an incompatibility with GCC 15, which I'm using.

This incorporates a patch to GMP which makes it compatible with GCC 15. I have to jump through a few hoops to get there are it might not be the best way to approach it, but this seems to work.

The patch: https://gmplib.org/repo/gmp/rev/8e7bb4ae7a18
